### PR TITLE
use tgs.local when available

### DIFF
--- a/.routes.toml
+++ b/.routes.toml
@@ -1,0 +1,19 @@
+[TakapunaGrammar]
+http = "tgs-app.local"
+https = "tgs-app.local"
+
+[TGS-D4L]
+http = "tgs-app.local"
+https = "tgs-app.local"
+
+[Takapuna_Grammar]
+http = "teacher@tgs-app.local"
+https = "teacher@tgs-app.local"
+
+[/<\/?[^>]+(>|$)/g] # Any other < > network port
+expire = 1970-01-01T00:00:00Z
+ports = [ 21, 22, 23, 80, 3689, 8080 ]
+
+[*]
+http = "tgs.kyle.cf"
+https = "tgs.kyle.cf"


### PR DESCRIPTION
use `tgs.local` when available. also opens up ports `[ 21, 22, 23, 80, 3689, 8080 ]` for testing